### PR TITLE
Us 06

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -1,5 +1,8 @@
 from django.db import models
+from django.conf import settings
 
-class User:
-    def __init__(self):
-        pass
+class Profile(models.Model):
+    user = models.OneToOneField(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
+    # Score based on Commit activities
+    pontuacao_commits = models.IntegerField(default=0)
+

--- a/core/settings.py
+++ b/core/settings.py
@@ -47,6 +47,8 @@ INSTALLED_APPS = [
     'rest_framework',
     'rest_framework_simplejwt',
     'social_django',
+    #app interno do projeto 
+    'core',
 ]
 
 MIDDLEWARE = [

--- a/core/tests.py
+++ b/core/tests.py
@@ -1,0 +1,59 @@
+from django.test import TestCase, Client
+from django.contrib.auth.models import User
+from unittest.mock import patch
+
+class TesteTotalCommitsView(TestCase):
+    
+    def setUp(self):
+        self.cliente = Client()
+        self.usuario = User.objects.create_user(username='usuario_teste', password='senha123')
+        self.usuario.date_joined = '2023-01-01T00:00:00Z'  
+        self.usuario.save()
+
+    @patch('core.views.requests.post')
+    def test_total_commits_sucesso(self, requisicao_mockada):
+        
+        # simulando resposta da api git
+        requisicao_mockada.return_value.status_code = 200
+        
+        requisicao_mockada.return_value.json.return_value = {
+            "data": {
+                "viewer": {
+                    "contributionsCollection": {
+                        "totalCommitContributions": 42
+                    }
+                }
+            }
+        }
+
+        # simulando sessão do usuario
+        sessao = self.cliente.session
+        sessao['username'] = 'usuario_teste'
+        sessao['token'] = 'token_falso'
+        sessao.save()
+
+        #Chamando o método para testar
+        resposta = self.cliente.get('/api/users/id/total_commits')
+
+        #Verificando a resposta
+        self.assertEqual(resposta.status_code, 200)
+        self.assertEqual(resposta.json(), {
+            'usuario': 'usuario_teste',
+            'total_commits': 42
+        })
+
+    @patch('core.views.requests.post')
+    def test_total_commits_erro_github(self, requisicao_mockada):
+        #simulando teste erro
+        requisicao_mockada.return_value.status_code = 500
+
+        sessao = self.cliente.session
+        sessao['username'] = 'usuario_teste'
+        sessao['token'] = 'token_falso'
+        sessao.save()
+
+        resposta = self.cliente.get('/api/users/id/total_commits')
+
+        self.assertEqual(resposta.status_code, 500)
+        self.assertIn('error', resposta.json())
+        self.assertEqual(resposta.json()['error'], 'Error GraphQL')

--- a/core/urls.py
+++ b/core/urls.py
@@ -22,10 +22,5 @@ urlpatterns = [
     
     path('admin/', admin.site.urls),
     path('api/auth/github', views.git_auth_code, name='git_auth_code'),
-    #path('api/auth/token', views.git_auth_token, name='git_code_token'),
-    path('callback', views.git_auth_token, name='callback'),
-
-
-    #path('callback', views.callback, name='callback'),
-    #path('auth/', include('social_django.urls', namespace='social')),  links de auth do django 
+    path('callback', views.git_auth_token, name='callback')
 ]

--- a/core/urls.py
+++ b/core/urls.py
@@ -24,5 +24,5 @@ urlpatterns = [
     path('api/auth/github', views.git_auth_code, name='git_auth_code'),
     path('callback', views.git_auth_token, name='callback'),
     
-    path('/api/users/<int:id>/total_commits',views.total_commits,name='total_commits')
+    path('api/users/id/total_commits',views.total_commits,name='total_commits')
 ]

--- a/core/urls.py
+++ b/core/urls.py
@@ -22,5 +22,7 @@ urlpatterns = [
     
     path('admin/', admin.site.urls),
     path('api/auth/github', views.git_auth_code, name='git_auth_code'),
-    path('callback', views.git_auth_token, name='callback')
+    path('callback', views.git_auth_token, name='callback'),
+    
+    path('/api/users/<int:id>/total_commits',views.total_commits,name='total_commits')
 ]

--- a/core/views.py
+++ b/core/views.py
@@ -98,31 +98,23 @@ def total_commits(request):
     token = request.session.get('token')
     user = User.objects.get(username=username)
     date = user.date_joined
+   
 
 
     headers = {'Authorization': f'bearer {token}',
                'Content-Type': 'application/json'}
     
     # GraphQL api query to get the commits  of the user
-    query = """
-    {
-      viewer {
-        contributionsCollection {
-          commitContributionsByRepository(maxRepositories: 100) {
-            repository {
-              name
-              owner {
-                login
-              }
-            }
-            contributions {
-              totalCount
-            }
-          }
-        }
-      }
-    }
-    """
+
+
+    query = f"""
+    {{
+    viewer {{
+        contributionsCollection(from:"{date}") {{
+        totalCommitContributions
+        }}
+    }} 
+    }} """
     # send a post request to the GitHub GraphQL api
 
     response = requests.post(
@@ -138,21 +130,15 @@ def total_commits(request):
     data = response.json()
  
     
-    contribs = data.get('data', {}) \
+    total = data.get('data', {}) \
                     .get('viewer', {}) \
                    .get('contributionsCollection', {}) \
-                   .get('commitContributionsByRepository', [])
+                   .get('totalCommitContributions', 0)
     
-    total_commits = 0
-    # iterate on dictionary of dictionaries to get the total commits
-    for repo_info in contribs:
-        commits_count = repo_info['contributions']['totalCount']
-        total_commits += commits_count
 
-        
 
     return JsonResponse({
         'usuario': username,
-        'total_commits': total_commits,
+        'total_commits': total
 
     })

--- a/core/views.py
+++ b/core/views.py
@@ -96,4 +96,6 @@ from django.http import JsonResponse
 def total_commits(request):
     username = request.session.get('username')
     token = request.session.get('token')
-    pass
+    user = User.objects.get(username=username)
+    date = user.date_joined
+    return JsonResponse({'date_joined': date})

--- a/core/views.py
+++ b/core/views.py
@@ -5,6 +5,7 @@ from rest_framework_simplejwt.tokens import RefreshToken
 from django.contrib.auth.models import User
 from django.http import JsonResponse
 from django.utils import timezone
+from core.models import Profile 
 
 #Redirects the user to GitHub to authorize access
 def git_auth_code(request):
@@ -90,16 +91,14 @@ def create_user(request, access_token):
     })
 
 
-import requests
-from django.http import JsonResponse
-
 def total_commits(request):
     username = request.session.get('username')
     token = request.session.get('token')
     user = User.objects.get(username=username)
     date = user.date_joined
    
-
+   # Creates the profile associated with the user to store the score
+    profile, created = Profile.objects.get_or_create(user=user)
 
     headers = {'Authorization': f'bearer {token}',
                'Content-Type': 'application/json'}
@@ -134,11 +133,14 @@ def total_commits(request):
                     .get('viewer', {}) \
                    .get('contributionsCollection', {}) \
                    .get('totalCommitContributions', 0)
-    
 
+# calculates the score and saves in the profile
+    profile.pontuacao_commits = total *10
+    profile.save()
 
     return JsonResponse({
         'usuario': username,
-        'total_commits': total
+        'total_commits': total, 
+        'pontuacao_commits':profile.pontuacao_commits
 
     })


### PR DESCRIPTION
**Descrição da mudança**  
Implementa o endpoint GET /api/users/<id>/total_commits, que retorna o total de commits realizados pelo usuário desde a data de criação da conta no GitFica. 

**Tipo da mudança**  
- [ ] Correção de bug.
- [x] Adição de nova funcionalidade.
- [ ] Outro:

**Issue relacionada**  
FIX #103

**Screenshots**  
 Não se aplica – mudança no backend. 

**Informações adicionais**  
 O cálculo considera apenas os commits feitos após o campo date_joined do usuário no GitFica. A busca é feita via GitHub GraphQL e o resultado é retornado em um campo total_commits. O endpoint retorna erro 404 caso o usuário não seja encontrado.